### PR TITLE
Solved bug for showing space between main two divs refer issue #73

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -198,8 +198,8 @@ h6 {
   flex-direction: row;
   justify-content: space-around;
   flex-wrap: wrap;
-  margin-left: 10rem;
-  margin-right: 10rem;
+  margin-left: 5rem;
+  margin-right: 5rem;
   .home-left, .home-right  {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
refer  #73

There is no space between "INDIA COVID-19 TRACKER" and "STATISTICS BY STATE" titled div in laptop view
by reducing ***margin to 5rem*** on home div solves the issue